### PR TITLE
Add-code-highlighting-with-sugar-high

### DIFF
--- a/app/blog/example-mdx-metadata/page.mdx
+++ b/app/blog/example-mdx-metadata/page.mdx
@@ -1,0 +1,36 @@
+# How to Export Metadata from MDX for Next.js SEO
+
+Next.js supports exporting a `metadata` object from your MDX files, which can be used to enhance SEO and social sharing features. This is especially useful for blog posts and documentation pages.
+
+## Example: Exporting Metadata
+
+You can export a `metadata` object at the top of your MDX file like this:
+
+```javascript
+export const metadata = {
+  title: 'How to Export Metadata from MDX for Next.js SEO',
+  description: 'A guide on exporting metadata from MDX files to leverage Next.js SEO features.',
+  authors: [{ name: 'Jane Doe', url: 'https://janedoe.com' }],
+  openGraph: {
+    images: [
+      'https://cdn.cosmos.so/example-image.jpg',
+    ],
+  },
+}
+```
+
+This metadata will be picked up by Next.js and can be used for SEO, Open Graph, and other meta tags.
+
+## Why Use Metadata in MDX?
+
+- **SEO**: Improve your page's search engine ranking with relevant titles and descriptions.
+- **Social Sharing**: Enhance how your content appears when shared on social media platforms.
+- **Consistency**: Keep your metadata close to your content for easier management.
+
+## Further Reading
+- [Next.js Documentation: Metadata](https://nextjs.org/docs/app/building-your-application/optimizing/metadata)
+- [MDX Documentation](https://mdxjs.com/)
+
+---
+
+_This post demonstrates how to export metadata from MDX files for use with Next.js SEO features, inspired by [leerob's site](https://github.com/leerob/site/blob/main/app/n/product-engineers/page.mdx)._ 

--- a/app/data.ts
+++ b/app/data.ts
@@ -95,6 +95,12 @@ export const BLOG_POSTS: BlogPost[] = [
     link: '/blog/exploring-the-intersection-of-design-ai-and-design-engineering',
     uid: 'blog-3',
   },
+  {
+    title: 'How to Export Metadata from MDX for Next.js SEO',
+    description: 'A guide on exporting metadata from MDX files to leverage Next.js SEO features.',
+    link: '/blog/example-mdx-metadata',
+    uid: 'blog-4',
+  },
 ]
 
 export const SOCIAL_LINKS: SocialLink[] = [

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,3 +19,14 @@
     border-color: var(--color-gray-200, currentColor);
   }
 }
+
+:root {
+  --sh-class: #7aa2f7;
+  --sh-sign: #89ddff;
+  --sh-string: #9ece6a;
+  --sh-keyword: #bb9af7;
+  --sh-comment: #565f89;
+  --sh-jsxliterals: #7aa2f7;
+  --sh-property: #73daca;
+  --sh-entity: #e0af68;
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,4 +1,6 @@
 import type { MDXComponents } from 'mdx/types'
+import { ComponentPropsWithoutRef } from 'react'
+import { highlight } from 'sugar-high'
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
@@ -18,6 +20,10 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
           <figcaption className="text-center">{caption}</figcaption>
         </figure>
       )
+    },
+    code: ({ children, ...props }: ComponentPropsWithoutRef<'code'>) => {
+      const codeHTML = highlight(children as string)
+      return <code dangerouslySetInnerHTML={{ __html: codeHTML }} {...props} />
     },
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "next-themes": "^0.4.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sugar-high": "^0.9.3",
         "tailwind-merge": "^2.5.5"
       },
       "devDependencies": {
@@ -6379,6 +6380,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/sugar-high": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/sugar-high/-/sugar-high-0.9.3.tgz",
+      "integrity": "sha512-sjJH8J76D1dRMU3QINnsYr1wfQyXbyEVQQvdgzJvIer6mkgM8ahB9fNrb+FDWzRKsLuITiBOR0ZbbhDZDUbqjg=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sugar-high": "^0.9.3",
     "tailwind-merge": "^2.5.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Add code highlight functionality with custom css variables based on [sugar-high](https://github.com/huozhi/sugar-high).

Includes example blog post to showcase highlighted code in blog.