### PR TITLE
Remove redundant config option

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,6 @@ import createMDX from '@next/mdx';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
 };
 


### PR DESCRIPTION
Strict Mode is enabled by default since Next.js 13.5.1 with the `app` router.

Ref: https://nextjs.org/docs/app/api-reference/config/next-config-js/reactStrictMode